### PR TITLE
Prevents running scripts in packages if they don't exist

### DIFF
--- a/src/utils/yarn.js
+++ b/src/utils/yarn.js
@@ -5,6 +5,8 @@ import * as processes from './processes';
 export async function run(pkg: Package, script: string, args: Array<string> = []) {
   let spawnArgs = ['run', script, '-s'];
 
+  if (!pkg.config.scripts || !pkg.config.scripts[script]) return;
+
   if (args.length) {
     spawnArgs = spawnArgs.concat('--', args);
   }


### PR DESCRIPTION
I ran into a bunch of issues with preinstall and postinstall scripts not being present.

We are getting the same issue in CI too. For Trey, it seems to happen in node 8.4.0 and not 8.1.4. 
It seems to happen to me in both versions (and CI is running 8.1.4).

In either case this seemed logical?