### PR TITLE
Run npm.info in getUnpublishedPackages in parallel

### DIFF
--- a/src/utils/getUnpublishedPackages.js
+++ b/src/utils/getUnpublishedPackages.js
@@ -6,19 +6,19 @@ export default async function getUnpublishedPackages(opts: { cwd?: string } = {}
   const cwd = opts.cwd || process.cwd();
   const project = await Project.init(cwd);
   const workspaces = await project.getWorkspaces();
-  const unpublishedPackages = [];
 
-  for (let workspace of workspaces) {
-    const packageInfo = await npm.info(workspace.pkg.config.name);
+  const results = await Promise.all(workspaces.map(async workspace => {
+    let config = workspace.pkg.config;
+    let packageInfo = await npm.info(config.name);
 
-    if (packageInfo.version !== workspace.pkg.config.version) {
-      unpublishedPackages.push({
-        name: packageInfo.name,
-        version: packageInfo.version,
-        previousVersion: workspace.pkg.config.version,
-      });
-    }
-  }
+    return {
+      name: packageInfo.name,
+      version: packageInfo.version,
+      previousVersion: config.version,
+    };
+  }));
 
-  return unpublishedPackages;
+  return results.filter(result => {
+    return result.version !== result.previousVersion;
+  });
 }


### PR DESCRIPTION
This was running serially, this should speed it up quite a bit

@lukebatchelor 
